### PR TITLE
remove redundant mkdir of sessions folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Webui can be found at `<your-ip>:80` , configuration files for rtorrent are in /
 
 ** Important note for user running services such as a webserver on port 80, change port 80 assignment **
 
-`** It should also be noted that this container when run will create subfolders ,completed, incoming, sessions and watched in the /downloads volume.**`
+`** It should also be noted that this container when run will create subfolders ,completed, incoming and watched in the /downloads volume.**`
 
+Umask can be set in the /config/rtorrent/rtorrent.rc file by changing value in `system.umask.set` 
 
 ## Info
 
@@ -77,7 +78,8 @@ Webui can be found at `<your-ip>:80` , configuration files for rtorrent are in /
 
 ## Versions
 
-+ **21.09.16:** Fix umask.
++ **04.10.16:** Remove redundant sessions folder.
++ **30.09.16:** Fix umask.
 + **21.09.16:** Bump mediainfo, reorg dockerfile, add full wget package.
 + **11.09.16:** Add layer badges to README.
 + **06.09.16:** Add badges to README.

--- a/root/defaults/rtorrent.rc
+++ b/root/defaults/rtorrent.rc
@@ -23,6 +23,7 @@ encryption = allow_incoming,try_outgoing,enable_retry
 dht = auto
 dht_port = 6881
 peer_exchange = yes
+# network.http.ssl_verify_peer.set=0
 # scgi_port = 0.0.0.0:5000
 encoding_list = UTF-8
 system.umask.set = 022

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -4,7 +4,7 @@
 mkdir -p \
 	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users} \
 	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
-	/downloads{/completed,/incoming,/sessions,/watched} \
+	/downloads{/completed,/incoming,/watched} \
 	/run{/nginx,/php} \
 	/var/lib/nginx/tmp/client_body
 
@@ -45,7 +45,7 @@ cp /config/php/php.ini /etc/php7/php.ini
 # permissions
 chown abc:abc \
 	/downloads \
-	/downloads{/completed,/incoming,/sessions,/watched}
+	/downloads{/completed,/incoming,/watched}
 
 chown -R abc:abc \
 	/config \

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
-umask 022
 
 exec \
 	screen -D -m -S \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- Remove redundant sessions folder in /downloads using /config for sessions
- Remove umask setting in run file and add information about changing it to the README
- Add commented out value for ignoring ssl to rtorrent.rc
