### PR TITLE
add package php7-mbstring and bump mediainfo to 0.7.90

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
-ARG MEDIAINF_VER="0.7.88"
+ARG MEDIAINF_VER="0.7.90"
 
 # install runtime packages
 RUN \
@@ -34,6 +34,7 @@ RUN \
 	php7-cgi \
 	php7-fpm \
 	php7-json  \
+	php7-mbstring \
 	php7-pear && \
 
 # install build packages

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Umask can be set in the /config/rtorrent/rtorrent.rc file by changing value in `
 
 ## Versions
 
++ **20.11.16:** Add php7-mbstring package, bump mediainfo to 0.7.90.
 + **14.10.16:** Add version layer information.
 + **04.10.16:** Remove redundant sessions folder.
 + **30.09.16:** Fix umask.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ add package php7-mbstring
+ bump mediainfo package to 0.7.90