### PR TITLE
Decouple rutorrent and logger service files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN \
 	php7-pear \
 	rtorrent \
 	screen \
+	sox \
 	tar \
 	unrar \
 	unzip \

--- a/root/etc/services.d/logger/run
+++ b/root/etc/services.d/logger/run
@@ -6,4 +6,4 @@ do
 done
 
 rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"
+tail -n 1 -f /config/log/rtorrent/rtorrent.log

--- a/root/etc/services.d/logger/run
+++ b/root/etc/services.d/logger/run
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bash
+
+until [ -e "/config/rtorrent/rtorrent_sess/rtorrent.lock" ];
+do
+    sleep 1s
+done
+
+rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
+tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -1,2 +1,5 @@
 #!/usr/bin/with-contenv bash
-rtorrent s6-setuidgid abc /usr/bin/rtorrent -n -o import=/config/rtorrent/rtorrent.rc
+
+screen -D -m -S \
+rtorrent s6-setuidgid abc /usr/bin/rtorrent \
+-n -o import=/config/rtorrent/rtorrent.rc

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -1,13 +1,2 @@
 #!/usr/bin/with-contenv bash
-
-	screen -D -m -S \
-	rtorrent s6-setuidgid abc /usr/bin/rtorrent \
-	-n -o import=/config/rtorrent/rtorrent.rc
-
-until [ -e "/config/rtorrent/rtorrent_sess/rtorrent.lock" ];
-do
-sleep 1s
-done
-
-rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"
+rtorrent s6-setuidgid abc /usr/bin/rtorrent -n -o import=/config/rtorrent/rtorrent.rc


### PR DESCRIPTION
with respect to [issue #22 ](https://github.com/linuxserver/docker-rutorrent-armhf/issues/22)

1. rutorrent service file has been decoupled into two separate services:
    * the first one responsible for rutorrent only
    * the second one responsible for printing rutorrent log file to stdout
2. [sox](https://linux.die.net/man/1/sox) has been added to the list of installed packages to avoid a warning in the web ui complaining that a plugin cannot find the sox executable
3. the `tail` command was followed for some reason by a variable containing the PID of rtorrent, but doing so resulted in having tail complaining that it couldn't find that file