### PR TITLE
Fixes typo with tail invocation

### DIFF
--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -10,4 +10,4 @@ sleep 1s
 done
 
 rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"
+tail -n 1 --pid="$rtorrent_pid" -f /config/log/rtorrent/rtorrent.log


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

PR commit log says it all. The `tail` invocation should include the `--pid` flag in order to follow the file until the pid dies. We aren't passing the flag as we're supposed to be.