### PR TITLE
Update base image to Alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.armhf:3.7
+FROM lsiobase/alpine.armhf:3.8
 
 # set version label
 ARG BUILD_DATE

--- a/root/defaults/rtorrent.rc
+++ b/root/defaults/rtorrent.rc
@@ -1,29 +1,32 @@
 execute = {sh,-c,/usr/bin/php7 /usr/share/webapps/rutorrent/php/initplugins.php abc &}
 execute.nothrow = rm,/run/php/.rtorrent.sock
+# network.scgi.open_port = 0.0.0.0:5000
 network.scgi.open_local = /run/php/.rtorrent.sock
-schedule = socket_chmod,0,0,"execute=chmod,0660,/run/php/.rtorrent.sock"
-schedule = socket_chgrp,0,0,"execute=chgrp,abc,/run/php/.rtorrent.sock"
+schedule2 = socket_chmod, 0, 0, "execute=chmod,0660,/run/php/.rtorrent.sock"
+schedule2 = socket_chgrp, 0, 0, "execute=chgrp,abc,/run/php/.rtorrent.sock"
+
+schedule2 = watch_directory_1, 5, 5, "load.start=/downloads/watched/*.torrent"
+schedule2 = low_diskspace, 5, 60, close_low_diskspace=100M
+
 log.open_file = "rtorrent", /config/log/rtorrent/rtorrent.log
 log.add_output = "info", "rtorrent"
-min_peers = 40
-max_peers = 1200
-max_uploads = 15
-download_rate = 10000
-upload_rate = 5000
-# schedule = watch_directory_1,5,5,"load.start=/downloads/watched/*.torrent"
-directory = /downloads/incoming
-session = /config/rtorrent/rtorrent_sess
-schedule = low_diskspace,5,60,close_low_diskspace=100M
-# ip = 178.32.28.51
-bind = 0.0.0.0
-port_range = 51413-51413
-check_hash = yes
-use_udp_trackers = yes
-encryption = allow_incoming,try_outgoing,enable_retry
-dht = auto
-dht_port = 6881
-peer_exchange = yes
+
+throttle.min_peers.normal.set = 40
+throttle.max_peers.normal.set = 1200
+throttle.max_uploads.set = 15
+throttle.global_down.max_rate.set_kb = 10000
+throttle.global_up.max_rate.set_kb = 5000
+directory.default.set = /downloads/incoming
+session.path.set = /config/rtorrent/rtorrent_sess
+# network.local_address.set = 178.32.28.51
+network.bind_address.set = 0.0.0.0
+network.port_range.set = 51413-51413
+pieces.hash.on_completion.set = yes
+trackers.use_udp.set = yes
+protocol.encryption.set = allow_incoming,try_outgoing,enable_retry
+dht.mode.set = auto
+dhg.port.set = 6881
+protocol.pex.set = yes
 # network.http.ssl_verify_peer.set=0
-# scgi_port = 0.0.0.0:5000
-encoding_list = UTF-8
+encoding.add = UTF-8
 # system.umask.set = 022


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
This updates the base image to Alpine 3.8, thereby allowing us to update rtorrent to v0.9.7 from the previous v0.9.6.

Due to deprecated commands actually being enforced now, apparently, we need to change some commands in the default rtorrent.rc file to get it to work out-of-box again. I decided to update all of them. to the non-deprecated form, per [the docs](https://github.com/rakshasa/rtorrent/wiki/rTorrent-0.9-Comprehensive-Command-list-(WIP)).

##  Thanks, team linuxserver.io

